### PR TITLE
Adding revoke_cert and delete_cert commands

### DIFF
--- a/ca/delete_cert.sh
+++ b/ca/delete_cert.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+MASTER="pe-201732-master.puppetdebug.vlan"
+AGENT="pe-201732-agent.puppetdebug.vlan"
+
+curl -k -X DELETE --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print cacert) "https://${MASTER}:8140/puppet-ca/v1/certificate_status/${AGENT}?environment=production"

--- a/ca/revoke_cert.sh
+++ b/ca/revoke_cert.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+MASTER="pe-201732-master.puppetdebug.vlan"
+AGENT="pe-201732-agent.puppetdebug.vlan"
+
+curl -k -X PUT -H 'Content-Type: application/json' --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print cacert) "https://${MASTER}:8140/puppet-ca/v1/certificate_status/${AGENT}?environment=production" -d '{"desired_state":"revoked"}'


### PR DESCRIPTION
revoke_cert and delete_cert can be used in combination to approximate a `puppet cert clean`.