### PR TITLE
Add some curl requests for the metadata_api

### DIFF
--- a/puppetserver/file_metadatas/get_file_metadata.sh
+++ b/puppetserver/file_metadatas/get_file_metadata.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Get the metadata for a specific file.
+# This example gets the file metadata for a fact.
+# Note: this checks the aio_agent_version.rb fact in the production environment. 
+# You can sub `plugins/facter` for `modules/<modulename>/<filename>` to check the metadata for a file in a module.
+
+curl --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print localcacert) "https://$(puppet config print server):8140/puppet/v3/file_metadata/plugins/facter/aio_agent_version.rb?environment=production" | python -m json.tool

--- a/puppetserver/file_metadatas/get_plugin_metadatas.sh
+++ b/puppetserver/file_metadatas/get_plugin_metadatas.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# A query to simulate what plugin sync will call to get the file metadatas for plugin sync.
+# Note: You can specify the environment in the command, which defaults to production
+
+curl --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print localcacert) "https://$(puppet config print server):8140/puppet/v3/file_metadatas/plugins?environment=production&links=follow&recurse=true&source_permissions=ignore&ignore=.svn&ignore=CVS&ignore=.git&ignore=.hg&checksum_type=md5" | python -m json.tool


### PR DESCRIPTION
This commit adds a few basic queries for checking the metadata from
puppetserver. These are the queries that the agent will run when pulling
the file metadata.